### PR TITLE
fixed MonoEntity registration with OnEnterPlaymode domain reload disabled

### DIFF
--- a/Assets/Plugins/Atomic/Entities/Scripts/Collections/EntityCollection`1.cs
+++ b/Assets/Plugins/Atomic/Entities/Scripts/Collections/EntityCollection`1.cs
@@ -125,7 +125,7 @@ namespace Atomic.Entities
                 return false;
 
             int hashCode = item.InstanceID;
-            int bucket = hashCode % _capacity;
+            int bucket = (hashCode & 0x7FFFFFFF) % _capacity;
             int current = _buckets[bucket];
 
             while (current != UNDEFINED_INDEX)
@@ -153,7 +153,7 @@ namespace Atomic.Entities
                 throw new ArgumentNullException(nameof(item));
 
             int hashCode = item.InstanceID;
-            int bucket = hashCode % _capacity;
+            int bucket = (hashCode & 0x7FFFFFFF) % _capacity;
             ref int head = ref _buckets[bucket];
 
             // Check if item already exists
@@ -202,7 +202,7 @@ namespace Atomic.Entities
                     _capacity = newCapacity;
 
                     // Recalculate bucket and head after resize
-                    bucket = hashCode % _capacity;
+                    bucket = (hashCode & 0x7FFFFFFF) % _capacity;
                     head = ref _buckets[bucket];
                 }
 
@@ -246,7 +246,7 @@ namespace Atomic.Entities
             var buckets = _buckets;
 
             int hash = item.InstanceID;
-            int bucket = hash % _capacity;
+            int bucket = (hash & 0x7FFFFFFF) % _capacity;
             ref int cur = ref buckets[bucket];
 
             while (true)

--- a/Assets/Plugins/Atomic/Entities/Scripts/Entities/Unity/MonoEntity_Registration.cs
+++ b/Assets/Plugins/Atomic/Entities/Scripts/Entities/Unity/MonoEntity_Registration.cs
@@ -7,17 +7,20 @@ namespace Atomic.Entities
 
         private void Register()
         {
-            if (_registered) 
+            if (_registered && _instanceId > 0)
                 return;
-            
+
             EntityRegistry.Instance.Register(this);
             _registered = true;
         }
-        
+
         private void Unregister()
         {
-            if (_registered) 
+            if (_registered)
+            {
                 EntityRegistry.Instance.Unregister(this);
+                _registered = false;
+            }
         }
     }
 }


### PR DESCRIPTION
It's the stale static/instance state, but the actual poisoned value is the actor's InstanceID == -1, and it comes from a _registered flag that never gets reset.

The chain:

MonoEntity registers itself through EntityRegistry.Instance (a static singleton). In the editor, this happens even in Edit Mode via ISerializationCallbackReceiver.OnAfterDeserialize → Register() (MonoEntity_UnityLifecycle.cs:78). That sets the private _registered = true (MonoEntity_Registration.cs:14).
With Disable Domain Reload, that static _instance and every MonoEntity._registered/_instanceId field survive between sessions (and from edit mode).
On entering Play Mode, [InitializeOnEnterPlayMode] EntityRegistry.ResetAll() → Clear() runs and resets each entity's InstanceID = UNDEFINED_INDEX (-1) (EntityRegistry.cs:490). But it cannot reset MonoEntity._registered — and Unregister() never sets it back to false anyway (MonoEntity_Registration.cs:17-21).
In the new session the actor calls Register() again → _registered is still true → early return → the actor never gets a fresh ID, so its InstanceID stays -1.
world.Add(actor) → int hashCode = item.InstanceID (= -1) → bucket = -1 % _capacity (= -1) → _buckets[-1] → IndexOutOfRangeException at EntityCollection\1.cs:157`.
The exception is a symptom, not the bug. EntityCollection.Add just never guards against a negative/zero hash (note its resize path masks with & 0x7FFFFFFF but Add/Contains don't), so a -1 ID reliably blows up the bucket index.